### PR TITLE
fix: Invalid `ID3v2` `artwork` base64 String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - AAC support with `.mp4` & `.m4a` file extensions.
 
+### Fixed
+
+- Invalid `ID3v2` `artwork` base64 string value.
+
 ### Changed
 
 - Enabled split apks, proguard, and shrink resources in React Native examples.

--- a/src/readers/ID3v2Reader.ts
+++ b/src/readers/ID3v2Reader.ts
@@ -255,7 +255,7 @@ export class ID3v2Reader extends FileReader {
       ? this.unsynchBuffer(this.buffer.position, frameSize)
       : frameSize;
 
-    this.skip(1);
+    const [encoding] = this.read(1);
     let pictureDataSize = newFrameSize - 1;
 
     let mimeType: string | undefined;
@@ -278,7 +278,7 @@ export class ID3v2Reader extends FileReader {
     }
 
     // Get description (field is of unknown length & ends with a `null`)
-    const description = this.readTilNull();
+    const description = this.readTilNull(encoding as Encoding);
     pictureDataSize -= description.length;
 
     const pictureData = this.read(pictureDataSize);


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, discussions, or feature requests.
-->

`AspecT` on Discord raised an issue with some `.mp3` files not having artwork associated with it, and showed a screenshot of the same files in a different program with artwork.

He provided one of the files with this issue and I replicated the same problem.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Doing a bit of investigating, I was logging the encoding for a picture frame and saw that it was different for this track compared to the others. Then I realized the problem, in which due to the encoding, the termination of reading the description would be different.
- Previously, we determined the end of a description to be when we hit a `0` byte.
- With the different encoding, it should have been when we hit 2 consecutive `0` bytes.

I kind of missed the text in the [mutagen docs](https://mutagen-specs.readthedocs.io/en/latest/id3/id3v2.4.0-frames.html#attached-picture) on the structure of a picture frame — it notes that the description is a text string according to encoding.
- The text encoding values can be found in the [ID3v2 frame overview of the mutagen docs](https://mutagen-specs.readthedocs.io/en/latest/id3/id3v2.4.0-structure.html#id3v2-frame-overview).

Basically, I had to update the `readTilNull()` function in the `FileReader`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Test to see if we render the image on the problematic file correctly through our example apps.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] Documentation is up to date to reflect these changes (ie: `CHANGELOG.md` & `README.md`).
- [x] Code is covered by new tests and passes existing tests.
- [x] This diff will work correctly for `pnpm rnfs-example android:prod`.
